### PR TITLE
Змінив формат лінків в git_course/resources

### DIFF
--- a/resources/readme.md
+++ b/resources/readme.md
@@ -2,27 +2,26 @@
 
 ## Завантаження
 
-* git + git Bash - https://git-scm.com/
-* VS Code - https://code.visualstudio.com/
-* GitHub Desktop - https://github.com/apps/desktop
+* [git + git Bash](https://git-scm.com/)
+* [VS Code](https://code.visualstudio.com/)
+* [GitHub Desktop](https://github.com/apps/desktop)
 
 ## Документація
 
-* Офіційна документація Git – https://git-scm.com/doc
-* Глибоке занурення в Git – https://git-scm.com/book/en/v2
-* Офіційна документація GitHub – https://docs.github.com/en
+* [Офіційна документація Git](https://git-scm.com/doc)
+* [Глибоке занурення в Git](https://git-scm.com/book/en/v2)
+* [Офіційна документація GitHub](https://docs.github.com/en)
   
 ## Шпаргалки
 
-* Шпаргалка для користувачів Git – https://education.github.com/git-cheat-sheet-education.pdf
-* Шпаргалка для форматування README.md – https://www.markdownguide.org/cheat-sheet/
-* Емодзі для README.md - https://dev.to/nikolab/complete-list-of-github-markdown-emoji-markup-5aia
+* [Шпаргалка для користувачів Git](https://education.github.com/git-cheat-sheet-education.pdf)
+* [Шпаргалка для форматування README.md](https://www.markdownguide.org/cheat-sheet/)
+* [Емодзі для README.md](https://dev.to/nikolab/complete-list-of-github-markdown-emoji-markup-5aia)
 
 ## Тренажери
 
-* Learn Git Branching - https://learngitbranching.js.org/?locale=en_US&utm_source=chatgpt.com
-* Oh My Git! - https://ohmygit.org/
-
+* [Learn Git Branching](https://learngitbranching.js.org/?locale=en_US&utm_source=chatgpt.com)
+* [Oh My Git!](https://ohmygit.org/0)
 ## Корисні репозиторії
 
 * https://github.com/sajal2692?tab=overview&from=2025-02-01&to=2025-02-11


### PR DESCRIPTION
Посилання були у форматі «назва - ресурс». Я переніс «ресурс» одразу  у назву, що робить сприйняття читача більш кращим.

Було:
![Знімок екрана 2025-03-19 101457](https://github.com/user-attachments/assets/62ea1fc7-fd29-4597-803f-c90f730dfc89)

Стало:
![image](https://github.com/user-attachments/assets/5e50291f-b83d-4e40-9bf3-6e3a59c0daad)
